### PR TITLE
update pytorch and cuda version

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,11 @@ git clone https://github.com/r4dl/StopThePop --recursive
 
 Our default, provided install method is based on Conda package and environment management:
 ```shell
-SET DISTUTILS_USE_SDK=1 # Windows only
 conda env create --file environment.yml
 conda activate stopthepop
 ```
-> **Note:** This process assumes that you have CUDA SDK **11** installed, not **12**.
+> **Note:** This process assumes that you have CUDA SDK **12.1** installed and linked in the environment variable `CUDA_HOME`. 
+For other CUDA versions, please update the environment.yml with a version supported by PyTorch.
 
 ### Running
 
@@ -554,6 +554,7 @@ If you further want to reduce the compile time, simply specify the exact ```CUDA
 
 ## Running the Real-Time Viewer
 https://github.com/r4dl/StopThePop/assets/45897040/5e763600-c0d9-4055-b664-0b9ea342a248
+
 
 <video width="99%" controls>
   <source src="assets/real-time-viewer-demo.mp4" type="video/mp4">

--- a/environment.yml
+++ b/environment.yml
@@ -3,16 +3,16 @@ channels:
   - pytorch
   - conda-forge
   - defaults
+  - nvidia
 dependencies:
-  - cudatoolkit=11.6
   - plyfile
-  - python=3.7.13
-  - pip=22.3.1
-  - pytorch=1.12.1
-  - torchaudio=0.12.1
-  - torchvision=0.13.1
+  - python=3.10
+  - pip
   - tqdm
   - dacite
+  - pytorch>=2.1
+  - pytorch-cuda=12.1
+  - torchvision
   - pip:
     - submodules/diff-gaussian-rasterization
     - submodules/simple-knn


### PR DESCRIPTION
managed to compile cuda extensions on Windows 11 using a 4090. Was getting errors before with other cuda/pytorch versions.

Tested on windows - worked well with CUDA 12.1 and PyTorch 2.3.
Not tested on Linux